### PR TITLE
Add DVF token

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -3,7 +3,7 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-shortlist.json",
   "name": "Linea Mainnet Token List",
   "createdAt": "2023-07-13",
-  "updatedAt": "2023-08-08",
+  "updatedAt": "2023-08-10",
   "versions": [
     {
       "major": 1,
@@ -63,8 +63,8 @@
       "name": "DeversiFi Token",
       "symbol": "DVF",
       "decimals": 18,
-      "createdAt": "2023-08-09",
-      "updatedAt": "2023-08-09",
+      "createdAt": "2023-08-10",
+      "updatedAt": "2023-08-10",
       "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/10759.png",
       "extension": {
         "rootChainId": 1,

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 4,
+      "minor": 5,
       "patch": 1
     }
   ],

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -55,6 +55,26 @@
     {
       "chainId": 59144,
       "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x1f031f8c523b339c7a831355879e3568fa3eb263",
+      "tokenType": [
+        "bridged"
+      ],
+      "address": "0x1f031f8c523b339c7a831355879e3568fa3eb263",
+      "name": "DeversiFi Token",
+      "symbol": "DVF",
+      "decimals": 18,
+      "createdAt": "2023-08-09",
+      "updatedAt": "2023-08-09",
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/10759.png",
+      "extension": {
+        "rootChainId": 1,
+        "rootChainURI": "https://etherscan.io/block/0",
+        "rootAddress": "0xdddddd4301a082e62e84e43f474f044423921918"
+      }
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
       "tokenId": "https://lineascan.build/address/0x0e5F2ee8C29e7eBc14e45dA7FF90566d8c407dB7",
       "tokenType": [
         "bridged"


### PR DESCRIPTION
Action: add
Context / rational: DVF token of rhino.fi is bridged to Linea via native bridge (https://lineascan.build/address/0x1f031f8c523b339c7a831355879e3568fa3eb263)

PR checklist:
- [x] I've kept the token list in alphabetical order based on token symbol
- [x] I've updated the `updatedAt` (and potentially `createdAt`) fields
- [x] I've update the list version number as per README instruction