### PR TITLE
fix: USDC decimals from 18 to 6

### DIFF
--- a/json/linea-goerli-token-shortlist.json
+++ b/json/linea-goerli-token-shortlist.json
@@ -3,12 +3,12 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-goerli-token-shortlist.json",
   "name": "Linea Goerli Token List",
   "createdAt": "2023-06-23",
-  "updatedAt": "2023-09-08",
+  "updatedAt": "2023-09-11",
   "versions": [
     {
       "major": 1,
       "minor": 2,
-      "patch": 2
+      "patch": 3
     }
   ],
   "tokens": [
@@ -126,9 +126,9 @@
       "address": "0xB4257F31750961C8e536f5cfCBb3079437700416",
       "name": "USD Coin",
       "symbol": "USDC",
-      "decimals": 18,
+      "decimals": 6,
       "createdAt": "2023-06-23",
-      "updatedAt": "2023-09-08",
+      "updatedAt": "2023-09-11",
       "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/3408.png",
       "extension": {
         "rootChainId": 5,


### PR DESCRIPTION
Action: add / update / remove token (keep those that applies)
update USDC decimals to 6 instead of 18
Context / rational:

PR checklist:
- [x] I've kept the token list in alphabetical order based on token symbol
- [x] I've updated the `updatedAt` (and potentially `createdAt`) fields
- [x] I've update the list version number as per README instruction