### PR TITLE
fix: get good token address

### DIFF
--- a/json/linea-goerli-token-shortlist.json
+++ b/json/linea-goerli-token-shortlist.json
@@ -16,7 +16,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0xD2340c4ec834bf43c05B9EcCd60EeD3a20892Dcc",
-      "tokenType": ["native"],
+      "tokenType": [
+        "native"
+      ],
       "address": "0xD2340c4ec834bf43c05B9EcCd60EeD3a20892Dcc",
       "name": "APE",
       "symbol": "APE",
@@ -29,7 +31,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0x5471ea8f739dd37E9B81Be9c5c77754D8AA953E4",
-      "tokenType": ["native"],
+      "tokenType": [
+        "native"
+      ],
       "address": "0x5471ea8f739dd37E9B81Be9c5c77754D8AA953E4",
       "name": "BNB",
       "symbol": "BNB",
@@ -42,7 +46,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0xeEfF322f4590A1A84BB3486d4BA0038669A811aD",
-      "tokenType": ["native"],
+      "tokenType": [
+        "native"
+      ],
       "address": "0xeEfF322f4590A1A84BB3486d4BA0038669A811aD",
       "name": "DOGE",
       "symbol": "DOGE",
@@ -55,8 +61,10 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0x6F03052743CD99ce1b29265E377e320CD24Eb632",
-      "tokenType": ["bridged"],
-      "address": "0x6F03052743CD99ce1b29265E377e320CD24Eb632",
+      "tokenType": [
+        "bridged"
+      ],
+      "address": "0x76292f4799f692C4d3C3a09F44982D4229A0d04B",
       "name": "HOP",
       "symbol": "HOP",
       "decimals": 18,
@@ -73,7 +81,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0xcAA61BCAe7D37Fe9C33c0D8671448254eef44D63",
-      "tokenType": ["native"],
+      "tokenType": [
+        "native"
+      ],
       "address": "0xcAA61BCAe7D37Fe9C33c0D8671448254eef44D63",
       "name": "Matic",
       "symbol": "MATIC",
@@ -86,7 +96,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0xD14754f4db08D19b5def26D33B94bdb5c3084c8a",
-      "tokenType": ["bridged"],
+      "tokenType": [
+        "bridged"
+      ],
       "address": "0xD14754f4db08D19b5def26D33B94bdb5c3084c8a",
       "name": "Meta Apes Peel",
       "symbol": "PEEL",
@@ -104,8 +116,10 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0x7823e8dcc8bfc23ea3ac899eb86921f90e80f499",
-      "tokenType": ["bridged"],
-      "address": "0x7823e8dcc8bfc23ea3ac899eb86921f90e80f499",
+      "tokenType": [
+        "bridged"
+      ],
+      "address": "0x0a981c2EBE4395562B4EE29FeBd137F2f843b115",
       "name": "Uniswap",
       "symbol": "UNI",
       "decimals": 18,
@@ -122,7 +136,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0xB4257F31750961C8e536f5cfCBb3079437700416",
-      "tokenType": ["bridged"],
+      "tokenType": [
+        "bridged"
+      ],
       "address": "0xB4257F31750961C8e536f5cfCBb3079437700416",
       "name": "USD Coin",
       "symbol": "USDC",
@@ -140,8 +156,10 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0x1990BC6dfe2ef605Bfc08f5A23564dB75642Ad73",
-      "tokenType": ["bridged"],
-      "address": "0x1990BC6dfe2ef605Bfc08f5A23564dB75642Ad73",
+      "tokenType": [
+        "bridged"
+      ],
+      "address": "0x43a4f69Fa1d2d69397393F6A4Deca9fA05714Af9",
       "name": "USD Tether",
       "symbol": "USDT",
       "decimals": 6,
@@ -158,7 +176,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0xDbcd5BafBAA8c1B326f14EC0c8B125DB57A5cC4c",
-      "tokenType": ["native"],
+      "tokenType": [
+        "native"
+      ],
       "address": "0xDbcd5BafBAA8c1B326f14EC0c8B125DB57A5cC4c",
       "name": "Wrapped Bitcoin",
       "symbol": "WBTC",
@@ -171,7 +191,9 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0x2C1b868d6596a18e32E61B901E4060C872647b6C",
-      "tokenType": ["native"],
+      "tokenType": [
+        "native"
+      ],
       "address": "0x2C1b868d6596a18e32E61B901E4060C872647b6C",
       "name": "Wrapped Ethereum",
       "symbol": "WETH",

--- a/json/linea-goerli-token-shortlist.json
+++ b/json/linea-goerli-token-shortlist.json
@@ -8,7 +8,7 @@
     {
       "major": 1,
       "minor": 2,
-      "patch": 4
+      "patch": 5
     }
   ],
   "tokens": [

--- a/json/linea-goerli-token-shortlist.json
+++ b/json/linea-goerli-token-shortlist.json
@@ -3,7 +3,7 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-goerli-token-shortlist.json",
   "name": "Linea Goerli Token List",
   "createdAt": "2023-06-23",
-  "updatedAt": "2023-09-15",
+  "updatedAt": "2023-09-29",
   "versions": [
     {
       "major": 1,

--- a/json/linea-goerli-token-shortlist.json
+++ b/json/linea-goerli-token-shortlist.json
@@ -60,7 +60,7 @@
     {
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
-      "tokenId": "https://goerli.lineascan.build/token/0x6F03052743CD99ce1b29265E377e320CD24Eb632",
+      "tokenId": "https://goerli.lineascan.build/token/0x76292f4799f692C4d3C3a09F44982D4229A0d04B",
       "tokenType": [
         "bridged"
       ],
@@ -115,7 +115,7 @@
     {
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
-      "tokenId": "https://goerli.lineascan.build/token/0x7823e8dcc8bfc23ea3ac899eb86921f90e80f499",
+      "tokenId": "https://goerli.lineascan.build/token/0x0a981c2EBE4395562B4EE29FeBd137F2f843b115",
       "tokenType": [
         "bridged"
       ],
@@ -155,7 +155,7 @@
     {
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
-      "tokenId": "https://goerli.lineascan.build/token/0x1990BC6dfe2ef605Bfc08f5A23564dB75642Ad73",
+      "tokenId": "https://goerli.lineascan.build/token/0x43a4f69Fa1d2d69397393F6A4Deca9fA05714Af9",
       "tokenType": [
         "bridged"
       ],


### PR DESCRIPTION
Action: add / update / remove token (keep those that applies)
Context / rational:
Some Tokens didn't have the addresses from the new message service.
Token addresses have been checked with 
https://goerli.lineascan.build/address/0x3ccd0F623B7a25Eab5dFc6a3fD723dCE5520489B#readProxyContract

![image](https://github.com/Consensys/linea-token-list/assets/7249024/0773a5a6-13da-4113-91b1-91f3fdc79602)

PR checklist:
- [X] I've kept the token list in alphabetical order based on token symbol
- [X] I've updated the `updatedAt` (and potentially `createdAt`) fields
- [X] I've update the list version number as per README instruction