### PR TITLE
Add USDLR to Linea token list

### DIFF
--- a/json/linea-mainnet-token-fulllist.json
+++ b/json/linea-mainnet-token-fulllist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 21,
+      "minor": 22,
       "patch": 0
     }
   ],
@@ -603,6 +603,26 @@
         "rootChainId": 1,
         "rootChainURI": "https://etherscan.io/block/0",
         "rootAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      }
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917",
+      "tokenType": [
+        "canonical-bridge"
+      ],
+      "address": "0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917",
+      "name": "USDLR by Stable",
+      "symbol": "USDLR",
+      "decimals": 6,
+      "createdAt": "2023-11-08",
+      "updatedAt": "2023-11-08",
+      "logoURI": "https://storage.googleapis.com/public.withstable.com/logos/usdlr/dark-circle.png",
+      "extension": {
+        "rootChainId": 1,
+        "rootChainURI": "https://etherscan.io/block/0",
+        "rootAddress": "0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917"
       }
     },
     {

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 11,
+      "minor": 12,
       "patch": 0
     }
   ],
@@ -446,6 +446,26 @@
         "rootChainId": 1,
         "rootChainURI": "https://etherscan.io/block/0",
         "rootAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      }
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917",
+      "tokenType": [
+        "canonical-bridge"
+      ],
+      "address": "0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917",
+      "name": "USDLR by Stable",
+      "symbol": "USDLR",
+      "decimals": 6,
+      "createdAt": "2023-11-08",
+      "updatedAt": "2023-11-08",
+      "logoURI": "https://storage.googleapis.com/public.withstable.com/logos/usdlr/dark-circle.png",
+      "extension": {
+        "rootChainId": 1,
+        "rootChainURI": "https://etherscan.io/block/0",
+        "rootAddress": "0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917"
       }
     },
     {


### PR DESCRIPTION
Action: add token
Context / rational:

USDLR is a fiat-backed stablecoin that pays DeFi protocols. We're working with several top DEXes on Linea.

PR checklist:
- [x] I've kept the token list in alphabetical order based on token symbol
- [x] I've updated the `updatedAt` (and potentially `createdAt`) fields
- [x] I've update the list version number as per README instruction