### PR TITLE
fix: goerli weth type from native to canonical-bridge

### DIFF
--- a/json/linea-goerli-token-shortlist.json
+++ b/json/linea-goerli-token-shortlist.json
@@ -171,7 +171,7 @@
       "chainId": 59140,
       "chainURI": "https://goerli.lineascan.build/block/0",
       "tokenId": "https://goerli.lineascan.build/token/0x2C1b868d6596a18e32E61B901E4060C872647b6C",
-      "tokenType": ["native"],
+      "tokenType": ["canonical-bridge"],
       "address": "0x2C1b868d6596a18e32E61B901E4060C872647b6C",
       "name": "Wrapped Ethereum",
       "symbol": "WETH",


### PR DESCRIPTION
Action: add / update / remove token (keep those that applies)
Context / rational:

PR checklist:
- [ ] I've kept the token list in alphabetical order based on token symbol
- [ ] I've updated the `updatedAt` (and potentially `createdAt`) fields
- [ ] I've update the list version number as per README instruction