### PR TITLE
fix: bump mainnet short list to v1.42.0

### DIFF
--- a/json/linea-goerli-token-shortlist.json
+++ b/json/linea-goerli-token-shortlist.json
@@ -104,9 +104,7 @@
       "chainId": 59144,
       "chainURI": "https://lineascan.build/block/0",
       "tokenId": "https://lineascan.build/address/0xE2a6e74118E708f7652FC4c74D2F9Ee5Fa210563",
-      "tokenType": [
-        "native"
-      ],
+      "tokenType": ["native"],
       "address": "0xE2a6e74118E708f7652FC4c74D2F9Ee5Fa210563",
       "name": "$NotWifGary",
       "symbol": "NWG",

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -3,11 +3,11 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-shortlist.json",
   "name": "Linea Mainnet Token List",
   "createdAt": "2023-07-13",
-  "updatedAt": "2024-05-24",
+  "updatedAt": "2024-05-27",
   "versions": [
     {
       "major": 1,
-      "minor": 41,
+      "minor": 42,
       "patch": 0
     }
   ],


### PR DESCRIPTION
Action: add / update / remove token (keep those that applies)
Context / rational:

PR checklist:
- [ ] I've verified and published the contract source
- [ ] I've kept the token list in alphabetical order based on token symbol
- [ ] I've updated the `updatedAt` (and potentially `createdAt`) fields
- [ ] I've updated the list version number as per README instruction
