### PR TITLE
Add WheatSol (SWHIT) token to Linea mainnet list

### DIFF
--- a/json/linea-mainnet-token-fulllist.json
+++ b/json/linea-mainnet-token-fulllist.json
@@ -2090,7 +2090,20 @@
         "rootChainId": 1,
         "rootChainURI": "https://etherscan.io/block/0",
         "rootAddress": "0x00000000fEB6A772307C6aA88AB9D57b209aCb18"
-      }
+      },
+{
+  "chainId": 59144,
+  "chainURI": "https://lineascan.build/block/0",
+  "tokenId": "https://lineascan.build/token/0x741f2fc08125a86d452d54ef77e24a9ca6da4cb2",
+  "tokenType": ["native"],
+  "address": "0x741f2fc08125a86d452d54ef77e24a9ca6da4cb2",
+  "name": "wheat-sol",
+  "symbol": "SWHIT",
+  "decimals": 18,
+  "createdAt": "2024-11-20",
+  "updatedAt": "2024-11-22",
+  "logoURI": "https://raw.githubusercontent.com/wheat-eco/wheatsol-asset/main/wheatsol.png"
+}
     }
   ]
 }

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -986,6 +986,19 @@
       "createdAt": "2024-04-24",
       "updatedAt": "2024-04-24",
       "logoURI": "https://assets.coingecko.com/coins/images/37375/standard/image.png?1714884543"
-    }
+    },
+{
+  "chainId": 59144,
+  "chainURI": "https://lineascan.build/block/0",
+  "tokenId": "https://lineascan.build/token/0x741f2fc08125a86d452d54ef77e24a9ca6da4cb2",
+  "tokenType": ["native"],
+  "address": "0x741f2fc08125a86d452d54ef77e24a9ca6da4cb2",
+  "name": "wheat-sol",
+  "symbol": "SWHIT",
+  "decimals": 18,
+  "createdAt": "2024-11-20",
+  "updatedAt": "2024-11-22",
+  "logoURI": "https://raw.githubusercontent.com/wheat-eco/wheatsol-asset/main/wheatsol.png"
+}
   ]
 }


### PR DESCRIPTION
**Action:** Add token

**Context / Rational:**  
Adding WheatSol (SWHIT) token to the Linea mainnet token list.

**PR checklist:**
- [x] I've verified and published the contract source
- [x] I've kept the token list in alphabetical order based on token symbol
- [x] I've updated the 'updatedAt' (and potentially 'createdAt') fields
- [x] I've updated the list version number as per README instruction

**Additional Information:**
- **Token Name:** Wheat-Sol
- **Token Symbol:** SWHIT
- **Contract Address:** 0x741f2fc08125a86d452d54ef77e24a9ca6da4cb2
- **Decimals:** 18
- **Chain:** Linea Mainnet (Chain ID: 59144)
- **Deployment Date:** 2024-11-20  
The token contract has been deployed and verified on LineaScan.

**Additional Project Information:**
- **GitHub:** [Wheat-sol](https://github.com/wheat-eco/wheat-eco)
- **Twitter:** [@Wheat-sol](https://x.com/wheat_linea?t=7krNOB8oneDdSvdqw9gp6A&s=09)
- **Telegram:** [Wheat-sol_channel](https://t.me/swhit_tg)

**Brief Project Description:**  
WheatSol (SWHIT) is a decentralized cryptocurrency token designed to power the WheatChain ecosystem. Its mission is to create a scalable and sustainable blockchain network for users to engage in decentralized finance (DeFi), participate in token-based incentives, and benefit from a transparent governance system. The WheatSol token will initially be Deployed on the Linea blockchain, with plans for broader adoption and integration with other chains like Aptos. The WheatChain ecosystem will be focused on accessibility, scalability, and incentivizing long-term growth for its community.