### PR TITLE
Feat/ausdc and ausdt

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -83,8 +83,8 @@
       "name": "Aave Linea USDC",
       "symbol": "aLinUSDC",
       "decimals": 6,
-      "createdAt": "2025-03-10",
-      "updatedAt": "2025-03-10",
+      "createdAt": "2025-02-11,
+      "updatedAt": "2025-02-11",
       "logoURI": "https://assets.coingecko.com/coins/images/14318/standard/aUSDC.e260d492.png"
     },
     {

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -75,6 +75,36 @@
     {
       "chainId": 59144,
       "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x374D7860c4f2f604De0191298dD393703Cce84f3",
+      "tokenType": [
+        "native"
+      ],
+      "address": "0x374D7860c4f2f604De0191298dD393703Cce84f3",
+      "name": "Aave Linea USDC",
+      "symbol": "aLinUSDC",
+      "decimals": 6,
+      "createdAt": "2025-02-11",
+      "updatedAt": "2025-02-11",
+      "logoURI": "https://assets.coingecko.com/coins/images/14318/standard/aUSDC.e260d492.png"
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x88231dfEC71D4FF5c1e466D08C321944A7adC673",
+      "tokenType": [
+        "native"
+      ],
+      "address": "0x88231dfEC71D4FF5c1e466D08C321944A7adC673",
+      "name": "Aave Linea USDT",
+      "symbol": "aLinUSDT",
+      "decimals": 6,
+      "createdAt": "2025-02-11",
+      "updatedAt": "2025-02-11",
+      "logoURI": "https://assets.coingecko.com/coins/images/14243/standard/aUSDT.78f5faae.png"
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
       "tokenId": "https://lineascan.build/address/0x5B16228B94b68C7cE33AF2ACc5663eBdE4dCFA2d",
       "tokenType": [
         "canonical-bridge"

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -3,11 +3,11 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-shortlist.json",
   "name": "Linea Mainnet Token List",
   "createdAt": "2023-07-13",
-  "updatedAt": "2025-01-15",
+  "updatedAt": "2025-03-10",
   "versions": [
     {
       "major": 1,
-      "minor": 50,
+      "minor": 51,
       "patch": 1
     }
   ],

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -83,8 +83,8 @@
       "name": "Aave Linea USDC",
       "symbol": "aLinUSDC",
       "decimals": 6,
-      "createdAt": "2025-02-11",
-      "updatedAt": "2025-02-11",
+      "createdAt": "2025-03-10",
+      "updatedAt": "2025-03-10",
       "logoURI": "https://assets.coingecko.com/coins/images/14318/standard/aUSDC.e260d492.png"
     },
     {
@@ -99,7 +99,7 @@
       "symbol": "aLinUSDT",
       "decimals": 6,
       "createdAt": "2025-02-11",
-      "updatedAt": "2025-02-11",
+      "updatedAt": "2025-03-10",
       "logoURI": "https://assets.coingecko.com/coins/images/14243/standard/aUSDT.78f5faae.png"
     },
     {

--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -99,7 +99,7 @@
       "symbol": "aLinUSDT",
       "decimals": 6,
       "createdAt": "2025-02-11",
-      "updatedAt": "2025-03-10",
+      "updatedAt": "2025-02-11",
       "logoURI": "https://assets.coingecko.com/coins/images/14243/standard/aUSDT.78f5faae.png"
     },
     {


### PR DESCRIPTION
Action: add AAVE's a tokens. aUSDC and uSDT
Context / rationale:
AAVE supplied tokens are represented by aTokens, used across the ecosystem

PR checklist:
- [x ] I've verified and published the contract source
- [ x] I've kept the token list in alphabetical order based on token symbol
- [x ] I've updated the `updatedAt` (and potentially `createdAt`) fields
- [x ] I've updated the list version number as per README instruction
