### PR TITLE
chore: add wDAI logo to Contentful

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -3,12 +3,12 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-shortlist.json",
   "name": "Linea Mainnet Token List",
   "createdAt": "2023-07-13",
-  "updatedAt": "2025-10-07",
+  "updatedAt": "2025-10-10",
   "versions": [
     {
       "major": 1,
       "minor": 59,
-      "patch": 3
+      "patch": 4
     }
   ],
   "tokens": [
@@ -1066,7 +1066,7 @@
       "decimals": 18,
       "createdAt": "2024-03-09",
       "updatedAt": "2024-03-09",
-      "logoURI": "https://harlequin-reluctant-parrotfish-147.mypinata.cloud/ipfs/bafkreidq3ezldzocsvmemshsgaq2mg35nl7bfm2xihc3zx3ppt2vu5vqc4",
+      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/4tHtSuU1jJnNMMs9su5d3E/1c05da70f431a7f545c90b70c7d49ef7/wdai_logo.png",
       "extension": {
         "rootChainId": 1,
         "rootChainURI": "https://etherscan.io/block/0",


### PR DESCRIPTION
**Action:** Update wDAI

**Context / Rationale:** Host the logo on Contentful instead of IPFS for performances reasons

---

### PR Checklist

- [ ] Verified and published the contract source
- [ ] Kept the token list in alphabetical order by token symbol
- [ ] Updated the `updatedAt` field (and `createdAt` if applicable)
- [ ] Updated the list version number according to the README instructions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `wDAI` logo to a Contentful URL and updates the shortlist `updatedAt` and patch version.
> 
> - **Tokens**:
>   - `wDAI`: Update `logoURI` to Contentful-hosted image in `json/linea-mainnet-token-shortlist.json`.
> - **Metadata**:
>   - Bump list version to `1.59.4`.
>   - Update top-level `updatedAt` to `2025-10-10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7377d9680219e670a0ee7f04b89df06a6957b066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->