### PR TITLE
Add iZi to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -385,8 +385,8 @@
       "name": "izumi Token",
       "symbol": "iZi",
       "decimals": 18,
-      "createdAt": "2025-11-07T10:03:48.116Z",
-      "updatedAt": "2025-11-07T10:03:48.116Z",
+      "createdAt": "2025-11-07",
+      "updatedAt": "2025-11-07",
       "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/5HjdkVgJPFTnLf0agf7ait/95878a7a79f54e156365c425bb54024a/image.png"
     },
     {


### PR DESCRIPTION
Add iZi to Linea token list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add iZi token to the Linea mainnet shortlist and bump the token list minor version to 1.64.0.
> 
> - **Tokens**:
>   - Add `izumi Token (iZi)` to `json/linea-mainnet-token-shortlist.json` with `address` `0x60d01ec2d5e98ac51c8b4cf84dfcce98d527c747`, `decimals` 18, and `logoURI`.
> - **Versioning**:
>   - Bump token list version to `1.64.0` in `versions.minor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00d2bb0b237847ee242cd7332fded09ecaca2ff9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->