### PR TITLE
Add sUSDe to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -819,8 +819,8 @@
       "name": "Staked USDe",
       "symbol": "sUSDe",
       "decimals": 18,
-      "createdAt": "2025-11-10T10:26:33.518Z",
-      "updatedAt": "2025-11-10T10:26:33.518Z",
+      "createdAt": "2025-11-10",
+      "updatedAt": "2025-11-10",
       "logoURI": "https://coin-images.coingecko.com/coins/images/33669/large/sUSDe-Symbol-Color.png?1716307680"
     },
     {


### PR DESCRIPTION
Add sUSDe to Linea token list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `sUSDe` (Staked USDe) to the Linea mainnet token shortlist and bumps version to 1.62.
> 
> - **Tokens**:
>   - Add `sUSDe` (Staked USDe) to `json/linea-mainnet-token-shortlist.json` with address `0x211cc4dd073734da055fbf44a2b4667d5e5fe5d2`, `decimals: 18`, and `logoURI`.
> - **Versioning**:
>   - Bump `versions[0].minor` from `61` to `62`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09c941a6c5e3dbd364e91d2c279d50fa4c0c6d09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->