### PR TITLE
Add TATERZ to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -886,7 +886,7 @@
       "decimals": 18,
       "createdAt": "2025-11-10",
       "updatedAt": "2025-11-10",
-      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/1jGcrN7biBE7xE3Qx2PEaN/6fbf788b4c68a54c994a3cd1d7420ad9/image.png"
+      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/1jGcrN7biBE7xE3Qx2PEaN/6964b7dfd9939fc2e765ac0f4e0e0448/Tater_Totz.png"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
Add TATERZ to Linea token list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds TATERZ token to the Linea mainnet token shortlist and bumps the list version minor to 66.
> 
> - **Token list (`json/linea-mainnet-token-shortlist.json`)**:
>   - Add `TATERZ` (`0xd221cf22B2B9643b44ba0873E08eC1952D52508a`) with `symbol` `TATERZ`, `decimals` 18, and `logoURI` provided.
> - **Versioning**:
>   - Bump `versions[0].minor` from `65` to `66`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81cf21bdb454257517a25f09b40282ef477131dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->