### PR TITLE
Add $TBAG to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -3,11 +3,11 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-shortlist.json",
   "name": "Linea Mainnet Token List",
   "createdAt": "2023-07-13",
-  "updatedAt": "2025-11-20",
+  "updatedAt": "2025-11-24",
   "versions": [
     {
       "major": 1,
-      "minor": 62,
+      "minor": 63,
       "patch": 0
     }
   ],
@@ -21,8 +21,8 @@
       "name": "TBAG",
       "symbol": "$TBAG",
       "decimals": 18,
-      "createdAt": "2025-11-10T14:19:03.147Z",
-      "updatedAt": "2025-11-10T14:19:03.147Z",
+      "createdAt": "2025-11-10",
+      "updatedAt": "2025-11-10",
       "logoURI": "https://coin-images.coingecko.com/coins/images/69384/large/TokenIcon.png?1758357855"
     },
     {


### PR DESCRIPTION
Add $TBAG to Linea token list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `$TBAG` (TBAG) to the Linea mainnet token shortlist and updates date/version metadata.
> 
> - **Token list (`json/linea-mainnet-token-shortlist.json`)**:
>   - Add `TBAG` (`$TBAG`) on `chainId` 59144 at `0x67454b41baf8d29751cc64f60e3c62b5634567a4` with `tokenType: ["native"]`, `decimals: 18`, and `logoURI`.
> - **Versioning/metadata**:
>   - `updatedAt`: `2025-11-24`.
>   - Bump `versions[0].minor` from `62` to `63`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 087f743e5544fd19100e4f7b3722b315b1b7933e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->