### PR TITLE
Add RUSTY to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -3,12 +3,12 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-shortlist.json",
   "name": "Linea Mainnet Token List",
   "createdAt": "2023-07-13",
-  "updatedAt": "2025-10-10",
+  "updatedAt": "2025-11-20",
   "versions": [
     {
       "major": 1,
-      "minor": 60,
-      "patch": 4
+      "minor": 61,
+      "patch": 0
     }
   ],
   "tokens": [
@@ -708,8 +708,8 @@
       "name": "RUSTY",
       "symbol": "RUSTY",
       "decimals": 18,
-      "createdAt": "2025-11-11T05:33:49.171Z",
-      "updatedAt": "2025-11-11T05:33:49.171Z",
+      "createdAt": "2025-11-11",
+      "updatedAt": "2025-11-11",
       "logoURI": "https://coin-images.coingecko.com/coins/images/68367/large/photo_2025-08-16_14-15-37.jpg?1755513766"
     },
     {


### PR DESCRIPTION
Add RUSTY to Linea token list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new tokens (RUSTY, Lybra Finance LBR, Etherex REX and REX33), bumps list to 1.61.0, and reorganizes token entries.
> 
> - **Tokens Added**:
>   - `RUSTY` (native) at `0x12bbdc004a0e9085ff94df1717336ecbc9f9e5fe`.
>   - `Lybra Finance (LBR)` (canonical-bridge) at `0x9D36f49D3d42B3A9BcC0f5Ac76fF8ef78fB2bC01`.
>   - `Etherex (REX)` (native) at `0xEfD81eeC32B9A8222D1842ec3d99c7532C31e348` and `Etherex Liquid Staking Token (REX33)` at `0xe4eEB461Ad1e4ef8b8EF71a33694CCD84Af051C4`.
> - **Metadata**:
>   - `updatedAt` set to `2025-11-20`.
>   - Version bumped to `1.61.0`.
> - **Maintenance**:
>   - Reorganized token entries and restored several canonical-bridge listings (e.g., `LINK`, `LUSD`, `USDP`, `USDT`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2f52277e89d8ab8641aa41a03cf7783d743868e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->