### PR TITLE
Add ETH to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 64,
+      "minor": 65,
       "patch": 0
     }
   ],
@@ -272,6 +272,19 @@
       "createdAt": "2024-06-17",
       "updatedAt": "2024-06-17",
       "logoURI": "https://lineascan.build/token/images/dysnfinnace_32.png"
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x0000000000000000000000000000000000000000",
+      "tokenType": ["native"],
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "Ether",
+      "symbol": "ETH",
+      "decimals": 18,
+      "createdAt": "2025-11-27T17:29:00.752Z",
+      "updatedAt": "2025-11-27T17:29:00.752Z",
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
Add ETH to Linea token list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add ETH to the Linea mainnet token list and bump list version to 1.65.
> 
> - **Token list (`json/linea-mainnet-token-shortlist.json`)**:
>   - **Add token**: `ETH` (name: `Ether`) on chain `59144`
>     - `address`: `0x0000000000000000000000000000000000000000`
>     - `symbol`: `ETH`, `decimals`: `18`
>     - `logoURI`: TrustWallet WETH icon URL
>   - **Version**: bump `versions.minor` from `64` to `65`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff6f66bb7668060ba227bbcd81400b69677b85c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->