### PR TITLE
[Dev Hub] Add ABT to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 64,
+      "minor": 65,
       "patch": 0
     }
   ],
@@ -42,6 +42,19 @@
         "rootChainURI": "https://etherscan.io/block/0",
         "rootAddress": "0x3F817b28Da4940F018C6b5c0A11C555ebB1264f9"
       }
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x29380Ed69d0012E2Fa825B7ECC8751ebB21Aa79d",
+      "tokenType": ["native"],
+      "address": "0x29380Ed69d0012E2Fa825B7ECC8751ebB21Aa79d",
+      "name": "ABT",
+      "symbol": "ABT",
+      "decimals": 18,
+      "createdAt": "2025-12-01",
+      "updatedAt": "2025-12-01",
+      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/1jYxqbettZFT8i4cVyFAze/ea5feeb097f94febfc6f89423a80b0bb/image.png"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
Add ABT to Linea token list from the Linea Developer Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ABT to the Linea mainnet token shortlist and bumps the list version to 1.65.
> 
> - **Token list updates**:
>   - Add `ABT` token to `json/linea-mainnet-token-shortlist.json` with address `0x29380Ed69d0012E2Fa825B7ECC8751ebB21Aa79d`, symbol `ABT`, and decimals `18`.
> - **Versioning**:
>   - Increment list version `minor` from `64` to `65`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed516e728a72acc3e08dfdd09e438a3b142b39e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->