### PR TITLE
update: DYSN

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -8,7 +8,7 @@
     {
       "major": 1,
       "minor": 64,
-      "patch": 0
+      "patch": 1
     }
   ],
   "tokens": [
@@ -264,7 +264,7 @@
       "chainId": 59144,
       "chainURI": "https://lineascan.build/block/0",
       "tokenId": "https://lineascan.build/address/0x65e413F21BF468Fed23996A8E701dD67FDf22B83",
-      "tokenType": ["native"],
+      "tokenType": ["canonical-bridge"],
       "address": "0x65e413F21BF468Fed23996A8E701dD67FDf22B83",
       "name": "Dyson Sphere",
       "symbol": "DYSN",


### PR DESCRIPTION
**Action:** Update 

**Context / Rationale:**
I want to be able to bridge the native $DYSN on Linea to L1, so I updated the token type to `canonical-bridge` instead of `native`.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reclassifies DYSN as a canonical-bridge token and increments the token list patch version.
> 
> - **Token list (`json/linea-mainnet-token-shortlist.json`)**:
>   - Bump `versions[0].patch` from `0` to `1`.
>   - Update `tokenType` for `Dyson Sphere (DYSN)` at `0x65e413F21BF468Fed23996A8E701dD67FDf22B83` from `["native"]` to `["canonical-bridge"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba2f5f8ad9dcd20db5a529a1bb4f353996d768e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->