### PR TITLE
update: DSYN token is now bridgeable

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 66,
+      "minor": 67,
       "patch": 0
     }
   ],
@@ -277,14 +277,19 @@
       "chainId": 59144,
       "chainURI": "https://lineascan.build/block/0",
       "tokenId": "https://lineascan.build/address/0x65e413F21BF468Fed23996A8E701dD67FDf22B83",
-      "tokenType": ["native"],
+      "tokenType": ["canonical-bridge"],
       "address": "0x65e413F21BF468Fed23996A8E701dD67FDf22B83",
       "name": "Dyson Sphere",
       "symbol": "DYSN",
       "decimals": 18,
       "createdAt": "2024-06-17",
       "updatedAt": "2024-06-17",
-      "logoURI": "https://lineascan.build/token/images/dysnfinnace_32.png"
+      "logoURI": "https://lineascan.build/token/images/dysnfinnace_32.png",
+      "extension": {
+        "rootChainId": 1,
+        "rootChainURI": "https://etherscan.io/block/0",
+        "rootAddress": "0xEc2d99DeA2c9E1d69c0A3C03FDC1776ECa24182a"
+      }
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
**Action:** Update DSYN

**Context / Rationale:**
DSYN is now bridgeable between Linea and Ethereum L1

---

### PR Checklist

- [ ] Verified and published the contract source
- [ ] Kept the token list in alphabetical order by token symbol
- [ ] Updated the `updatedAt` field (and `createdAt` if applicable)
- [ ] Updated the list version number according to the README instructions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `DYSN` on Linea as a `canonical-bridge` token with L1 mapping and bumps the token list minor version to 67.
> 
> - **Tokens**:
>   - `json/linea-mainnet-token-shortlist.json`:
>     - Update `DYSN` (`0x65e413F21BF468Fed23996A8E701dD67FDf22B83`): set `tokenType` to `canonical-bridge`; add `extension` with `rootChainId: 1`, `rootChainURI`, and `rootAddress: 0xEc2d99DeA2c9E1d69c0A3C03FDC1776ECa24182a`.
> - **Versioning**:
>   - Bump `versions[0].minor` from `66` to `67`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b2d41953f8042795e2bea291ff902ed573f3003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->