### PR TITLE
[Dev Hub] Add WRMY to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 71,
+      "minor": 72,
       "patch": 1
     }
   ],
@@ -1137,6 +1137,19 @@
       "createdAt": "2023-08-08",
       "updatedAt": "2023-08-08",
       "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2396.png"
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x2c2Dc9770c1185e76920C8e763c4833B7a02Dd1A",
+      "tokenType": ["native"],
+      "address": "0x2c2Dc9770c1185e76920C8e763c4833B7a02Dd1A",
+      "name": "Wormy",
+      "symbol": "WRMY",
+      "decimals": 18,
+      "createdAt": "2025-12-09",
+      "updatedAt": "2025-12-09",
+      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/5ucn47Sy04FShrb8treDqS/aefdc06e6769e2425ee14f8bd9882cf5/image.png"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
Add WRMY to Linea token list from the Linea Developer Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only change to a static token list (adds one token and updates version metadata) with no executable logic changes.
> 
> **Overview**
> Adds a new *native* token entry for `WRMY` (Wormy) at address `0x2c2Dc9770c1185e76920C8e763c4833B7a02Dd1A` to `json/linea-mainnet-token-shortlist.json`, including metadata (decimals, dates, logo).
> 
> Bumps the token list `versions` minor from `71` to `72` (with `updatedAt` set to `2026-02-12`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51d7729b5f53d14381411db9a45f1c4028b9cb8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->