### PR TITLE
[Dev Hub] Add SHRT to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 72,
+      "minor": 73,
       "patch": 1
     }
   ],
@@ -809,6 +809,19 @@
         "rootChainURI": "https://etherscan.io/block/0",
         "rootAddress": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
       }
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x60C2d7AF58dA5915Af06F5E7a0e49fc98271A4b3",
+      "tokenType": ["native"],
+      "address": "0x60C2d7AF58dA5915Af06F5E7a0e49fc98271A4b3",
+      "name": "Shortia Token",
+      "symbol": "SHRT",
+      "decimals": 18,
+      "createdAt": "2025-12-28",
+      "updatedAt": "2026-02-16",
+      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/3Ez4dkRa1nQSNO9fuAdZSY/36697bda38846396c9d75b6504e19e07/image.png"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
Add SHRT to Linea token list from the Linea Developer Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only change to a token list (new entry + version bump) with no runtime logic changes; main risk is incorrect token metadata/address causing downstream display or routing issues.
> 
> **Overview**
> Adds a new `SHRT` (Shortia Token) entry to `json/linea-mainnet-token-shortlist.json`, including address, metadata, and `logoURI`.
> 
> Bumps the token list `versions` minor number from `72` to `73` to reflect the updated shortlist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 845d50759ee26049b7132fbc088db23837f7bfd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->