### PR TITLE
[Dev Hub] Add FLAG to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 73,
+      "minor": 74,
       "patch": 1
     }
   ],
@@ -332,7 +332,7 @@
       "symbol": "FLAG",
       "decimals": 18,
       "createdAt": "2025-12-30",
-      "updatedAt": "2025-12-30",
+      "updatedAt": "2026-02-16",
       "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/1PiTC5Ry1s30slazDLauMf/044962435f9e73539026557df9fc088a/image.png"
     },
     {


### PR DESCRIPTION
Add FLAG to Linea token list from the Linea Developer Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static token list metadata update (adds one token and bumps version) with no code or runtime behavior changes.
> 
> **Overview**
> Adds the `FLAG` token entry to `json/linea-mainnet-token-shortlist.json` (Linea mainnet `chainId` 59144) with its contract address, metadata, and `logoURI`.
> 
> Bumps the token list `versions.minor` from `73` to `74` to reflect the updated shortlist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1de069fa614dc51bb25a4ea8ca1fb50a1e5975b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->