### PR TITLE
[Dev Hub] Add 1CHOOSE to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 67,
+      "minor": 75,
       "patch": 1
     }
   ],
@@ -22,7 +22,7 @@
       "symbol": "1CHOOSE",
       "decimals": 18,
       "createdAt": "2026-01-04",
-      "updatedAt": "2026-01-04",
+      "updatedAt": "2026-02-16",
       "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/7oNplDT8jL70nhxhHENL0A/318bb1adbd1cadb85d83f0499fa2fbea/image.png"
     },
     {


### PR DESCRIPTION
Add 1CHOOSE to Linea token list from the Linea Developer Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only change to a token list JSON; main risk is incorrect token metadata (address/decimals/logo) affecting downstream consumers.
> 
> **Overview**
> Adds the `1CHOOSE` token (Linea mainnet, `0x8717d1bd821fd8faf023fd6fb6087512182b477f`) to `json/linea-mainnet-token-shortlist.json`, including metadata and `logoURI`.
> 
> Bumps the token list version minor from `74` to `75` to reflect the updated shortlist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96a654aab2a33806fcae3dced72bed10fb85d006. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->