### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2.0.6
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/verify-json.yml
+++ b/.github/workflows/verify-json.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Pin every `uses:` ref in `.github/workflows/` (and any composite action
files) to a full 40-character commit SHA, with the original tag
preserved as a `# vX` comment.

## Why

Tags and branches are mutable, so a compromised action can replace what
runs in our pipelines without changing the tag we reference. Pinning to
a SHA closes that supply-chain vector. See GitHub's hardening guide:
<https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions>.

## Deadline

**TechOps is enforcing SHA-pinned GitHub Actions across the org by
June 8, 2026.** Merging this PR brings the repo into compliance ahead
of the cut-over; after that date workflows that still reference
mutable tags or branches will be blocked from running.

## How

Generated mechanically with [`pinact run`](https://github.com/suzuki-shunsuke/pinact).
No version bumps were applied (strict pin); follow-up upgrades can come
from Renovate or a separate `pinact run -u` PR.

## Test plan

- [ ] CI green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI workflow references are pinned to specific SHAs without changing job logic, but a wrong SHA could break runs until corrected.
> 
> **Overview**
> Pins `uses:` references in GitHub Actions workflows to full commit SHAs (e.g., `actions/checkout`, `actions/setup-node`, `actions/setup-python`, and MetaMask’s security scanner), preserving the prior tag/version as a comment.
> 
> This hardens the CI supply chain by removing mutable tag/branch references while keeping the workflows’ behavior otherwise the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce5632ea3a354627943e993f9576f489c47478b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->