### PR TITLE
[Dev Hub] Add BNB to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 78,
+      "minor": 79,
       "patch": 1
     }
   ],
@@ -156,6 +156,19 @@
       "createdAt": "2024-12-04",
       "updatedAt": "2024-12-04",
       "logoURI": "https://assets.coingecko.com/coins/images/68370/standard/91ba3d27-4051-4329-b6cc-36bda5872b4d.jpeg?1755634398"
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0xf5c6825015280cdfd0b56903f9f8b5a2233476f5",
+      "tokenType": ["native"],
+      "address": "0xf5C6825015280CdfD0b56903F9F8B5A2233476F5",
+      "name": "Binance Coin",
+      "symbol": "BNB",
+      "decimals": 18,
+      "createdAt": "2026-05-12",
+      "updatedAt": "2026-05-12",
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53084/large/wrapped_bnb.png?1735264592"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
Add BNB to Linea token list from the Linea Developer Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates a static token list JSON by adding one new token entry and bumping the list minor version; main risk is incorrect token metadata/address affecting downstream consumers.
> 
> **Overview**
> Adds `BNB (Binance Coin)` to `json/linea-mainnet-token-shortlist.json` (Linea mainnet, `chainId` 59144) with address, decimals, and `logoURI` metadata.
> 
> Bumps the token list `versions.minor` from `78` to `79` and updates the file formatting to end without a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbe4cdd2649f7633e357cb77c13956dc691917ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->