### PR TITLE
ci(global): pin security scanner workflow

### DIFF
--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -15,16 +15,19 @@ on:
         required: false
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2.0.6
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@0a58c584f25e8c121927884b5e8a86e846090e5c # post-v2.0.6
     permissions:
       actions: read
       contents: read
       security-events: write
     with:
       repo: ${{ github.repository }}
-      scanner-ref: 'v2'
+      scanner-ref: '0a58c584f25e8c121927884b5e8a86e846090e5c' # post-v2.0.6
       paths-ignored: |
         node_modules
         **/node_modules/**


### PR DESCRIPTION
## Summary

- Update the MetaMask security scanner reusable workflow to a pinned commit that uses fully pinned nested actions.
- Pin `scanner-ref` to the same commit so the workflow does not check out the old `v2` tag internally.
- Add a minimal top-level workflow `permissions` block for zizmor.

## Root Cause

The previous pinned scanner commit corresponded to `v2.0.6`, whose reusable workflow still referenced unpinned actions internally. Updating only the reusable workflow reference was not enough because `scanner-ref: v2` made the scanner checkout return to the old tag during setup. The updated scanner also runs zizmor, which requires explicit minimal workflow permissions.

## Validation

- `npm run prettier`
- Verified the selected scanner commit uses full-length SHAs for `actions/checkout`, `actions/setup-node`, CodeQL, setup-java, zizmor, and Slack actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow pinning and permissions; no application runtime or auth/data paths change.
> 
> **Overview**
> **Pins the MetaMask security code scanner CI workflow** to commit `0a58c584` (post-`v2.0.6`) instead of the previous `v2.0.6` pin, so the reusable workflow and its nested actions run from a revision with fully SHA-pinned dependencies.
> 
> **Aligns `scanner-ref`** with that same commit instead of the `v2` tag, so the scanner’s internal checkout does not fall back to the older tag during setup.
> 
> **Adds a top-level `permissions: contents: read`** on the caller workflow to satisfy zizmor checks introduced in the updated scanner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ec8f26352d90f1dfb7fdd7ebbd1d4a294137f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->