### PR TITLE
[Dev Hub] Add LDAT to Linea token list

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -7,7 +7,7 @@
   "versions": [
     {
       "major": 1,
-      "minor": 78,
+      "minor": 79,
       "patch": 1
     }
   ],
@@ -481,6 +481,19 @@
         "rootChainURI": "https://etherscan.io/block/0",
         "rootAddress": "0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202"
       }
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x02F289E429655d0C0D713A7dFD26850A81f7cFC5",
+      "tokenType": ["native"],
+      "address": "0x02F289E429655d0C0D713A7dFD26850A81f7cFC5",
+      "name": "LDAT",
+      "symbol": "LDAT",
+      "decimals": 18,
+      "createdAt": "2026-06-22",
+      "updatedAt": "2026-06-22",
+      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/1yJeLBT8PfDZ752Q6W6Ahd/7a63016d417ed8edd5656b9d4e0ca200/image.png"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
Add LDAT to Linea token list from the Linea Developer Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON metadata entry with no application or contract logic changes; main review risk is verifying the on-chain address and token metadata are correct.
> 
> **Overview**
> Adds **LDAT** (`0x02F289E429655d0C0D713A7dFD26850A81f7cFC5`) to `linea-mainnet-token-shortlist.json` as a Linea mainnet **native** token (18 decimals, Dev Hub logo URI).
> 
> The list version **minor** is bumped **78 → 79** per repo guidelines for new token entries; list `updatedAt` is already **2026-03-26** in this change set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2aa4ce51648f5b0690156d302563fbea6c92b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->