### PR TITLE
ci: update pinned GitHub Actions to their latest versions

### DIFF
--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -20,14 +20,14 @@ permissions:
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@0a58c584f25e8c121927884b5e8a86e846090e5c # post-v2.0.6
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@becb242930b3cc271c26da0280050db9c157e291 # v2.1.1
     permissions:
       actions: read
       contents: read
       security-events: write
     with:
       repo: ${{ github.repository }}
-      scanner-ref: '0a58c584f25e8c121927884b5e8a86e846090e5c' # post-v2.0.6
+      scanner-ref: 'becb242930b3cc271c26da0280050db9c157e291' # v2.1.1
       paths-ignored: |
         node_modules
         **/node_modules/**

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/verify-json.yml
+++ b/.github/workflows/verify-json.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Bumps the GitHub Actions pinned in this repo's workflows to their latest tagged releases:

| Workflow(s) | Action | From | To |
|---|---|---|---|
| `validate-json.yml`, `verify-json.yml` | `actions/checkout` | `v6.0.2` | `v7.0.0` |
| `validate-json.yml` | `actions/setup-python` | `v6.2.0` | `v6.3.0` |
| `security-code-scanner.yml` | `MetaMask/action-security-code-scanner` reusable workflow | untagged post-`v2.0.6` commit | `v2.1.1` (tagged release) |

`actions/setup-node` was already pinned to the latest release (`v6.4.0`) and is unchanged.

All actions remain pinned to a full commit SHA with a version comment, consistent with the repo's existing convention and its `sha_pinning_required` setting.

## Why these are safe upgrades

- **`actions/checkout` v7.0.0**: the only behavioral change is blocking fork-PR checkouts on `pull_request_target`/`workflow_run` triggers — none of these workflows use either trigger. Runtime (`node24`) is unchanged from v6.
- **`actions/setup-python` v6.3.0**: adds RHEL support and includes the Linux distro in cache keys; only effect here is a one-time cache-key change (first run after merge repopulates the pip cache), no functional change.
- **MetaMask security-code-scanner v2.1.1**: the reusable workflow's `inputs`/`secrets` interface is unchanged from the commit this repo was previously pinned to. Internally it adds a non-blocking `zizmor` GitHub Actions security scan (`continue-on-error: true`, reports to code scanning) — the caller job here already grants the `security-events: write` permission it needs.

## Test plan

- [ ] `validate-json.yml` passes on this PR (checkout + setup-python jobs)
- [ ] `verify-json.yml` passes on the next push to `main`
- [ ] `security-code-scanner.yml` completes successfully against the new scanner version, including the Slack/zizmor steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin updates with no application or runtime code changes; workflows here use standard `push`/`pull_request` triggers, so checkout v7’s fork-PR guard does not apply.
> 
> **Overview**
> Updates **SHA-pinned** third-party actions across CI workflows while keeping the same pin-by-commit convention.
> 
> **`validate-json.yml`** and **`verify-json.yml`** move **`actions/checkout`** from **v6.0.2** to **v7.0.0** on all checkout steps. **`validate-json.yml`** also bumps **`actions/setup-python`** from **v6.2.0** to **v6.3.0** in the JSON validation job. **`actions/setup-node`** stays on **v6.4.0**.
> 
> **`security-code-scanner.yml`** repoints the reusable **`MetaMask/action-security-code-scanner`** workflow and matching **`scanner-ref`** input from a post-**v2.0.6** commit to the tagged **v2.1.1** release (**`becb2429…`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a08d83338cdf25e5bbf5066f29e4688e23d6438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->