### PR TITLE
feat: add USDL

### DIFF
--- a/json/linea-mainnet-token-shortlist.json
+++ b/json/linea-mainnet-token-shortlist.json
@@ -3,12 +3,12 @@
   "tokenListId": "https://raw.githubusercontent.com/Consensys/linea-token-list/main/json/linea-mainnet-token-shortlist.json",
   "name": "Linea Mainnet Token List",
   "createdAt": "2023-07-13",
-  "updatedAt": "2026-03-26",
+  "updatedAt": "2026-08-05",
   "versions": [
     {
       "major": 1,
-      "minor": 79,
-      "patch": 1
+      "minor": 80,
+      "patch": 0
     }
   ],
   "tokens": [
@@ -530,6 +530,19 @@
         "rootChainURI": "https://etherscan.io/block/0",
         "rootAddress": "0x1789e0043623282d5dcc7f213d703c6d8bafbb04"
       }
+    },
+    {
+      "chainId": 59144,
+      "chainURI": "https://lineascan.build/block/0",
+      "tokenId": "https://lineascan.build/address/0x91C4596B9Aba38CB46318F01A0C1943922f47aE5",
+      "tokenType": ["native"],
+      "address": "0x91C4596B9Aba38CB46318F01A0C1943922f47aE5",
+      "name": "Linea USD",
+      "symbol": "USDL",
+      "decimals": 6,
+      "createdAt": "2026-07-22",
+      "updatedAt": "2026-07-22",
+      "logoURI": "https://images.ctfassets.net/4j2tco9amoqh/13g70nmIV6ieaT6an4O4cK/dd6445dbbb791665e0cde2c71af5294a/USDL_logo.png"
     },
     {
       "chainId": 59144,


### PR DESCRIPTION
## Description

**Action:** Add

**Token name:** USDL
**Network:** Mainnet / Sepolia (choose one)

**Context / Rationale:**

<!-- Brief explanation of why this change is needed -->

Closes #<!-- issue number, if applicable -->

---

## Type of Change

- [X] Token addition
- [ ] Token update (metadata, address, type)
- [ ] Token removal
- [ ] Documentation update
- [ ] Code change (scripts, config, CI)

## Checklist

- [ ] Verified and published the contract source on an explorer
- [ ] Kept the token list in alphabetical order by token name
- [ ] Updated the `updatedAt` field (and `createdAt` if applicable)
- [ ] Updated the list version number according to the
      [guidelines](./docs/development.md#guidelines)
- [ ] JSON conforms to the
      [schema](./json/schema/l2-token-list-schema.json)
- [ ] Did not modify the schema or template files
- [ ] No secrets, private keys, or real API keys in the diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON metadata change with no application code; main review risk is verifying the contract address and metadata, and that wallets won’t confuse USDL with the existing USDLR entry.
> 
> **Overview**
> Adds **Linea USD** (`USDL`) to `linea-mainnet-token-shortlist.json` as a **native** Linea mainnet token at `0x91C4596B9Aba38CB46318F01A0C1943922f47aE5` (6 decimals), placed alphabetically between Linea and Linea Velocore.
> 
> The list metadata is bumped per project guidelines: version **1.79.1 → 1.80.0** (minor for a new token) and `updatedAt` set to **2026-08-05**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc60c5ad05bd669e7b3511437a0809e614c68528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->